### PR TITLE
Applied mutation testing to improve the quality of the tests and the code for Java implementation.

### DIFF
--- a/java/src/main/java/me/everything/inbloom/BloomFilter.java
+++ b/java/src/main/java/me/everything/inbloom/BloomFilter.java
@@ -24,12 +24,12 @@ public class BloomFilter {
     // These fields are part of the public interface of this structure.
     // Client code may read these values if desired. Client code MUST NOT
     // modify any of these.
-    public int entries; 
-    public double error;
-    public int bits;
-    public int bytes;
-    public int hashes;
-    public static double errorPrecision = 0.000000001;
+    protected final int entries; 
+    protected final double error;
+    protected final int bits;
+    protected final int bytes;
+    protected final int hashes;
+    protected final static double errorPrecision = 0.000000001;
 
     // Fields below are private to the implementation. These may go away or
     // change incompatibly at any moment. Client code MUST NOT access or rely

--- a/java/src/main/java/me/everything/inbloom/BloomFilter.java
+++ b/java/src/main/java/me/everything/inbloom/BloomFilter.java
@@ -24,11 +24,12 @@ public class BloomFilter {
     // These fields are part of the public interface of this structure.
     // Client code may read these values if desired. Client code MUST NOT
     // modify any of these.
-    int entries;
-    double error;
-    int bits;
-    int bytes;
-    int hashes;
+    public int entries; 
+    public double error;
+    public int bits;
+    public int bytes;
+    public int hashes;
+    public static double errorPrecision = 0.000000001;
 
     // Fields below are private to the implementation. These may go away or
     // change incompatibly at any moment. Client code MUST NOT access or rely
@@ -59,7 +60,7 @@ public class BloomFilter {
      */
     public BloomFilter(byte []data, int entries, double error) throws RuntimeException
     {
-        if (entries < 1 || error == 0) {
+        if (entries < 1 || ( ( 1.0 <= error ) || ( error <= errorPrecision ) ) ) {
             throw new RuntimeException("Invalid params for bloom filter");
         }
 

--- a/java/src/test/java/me/everything/inbloom/BloomFilterTest.java
+++ b/java/src/test/java/me/everything/inbloom/BloomFilterTest.java
@@ -9,6 +9,102 @@ import java.io.InvalidObjectException;
  */
 public class BloomFilterTest extends TestCase {
 
+    public void testCreateFilterWithBadParameters()
+    {
+        try 
+        {
+            BloomFilter_mutated bf = new BloomFilter_mutated( -1, 0.01 );
+            fail( "should have thrown an exception" );
+        }
+        catch( RuntimeException e ) 
+        {
+            assertEquals( "Invalid params for bloom filter", e.getMessage() );
+        }
+        
+        //
+        // Error value cannot be arbitrarily close to zero. Must be bounded.
+        // 
+        try 
+        {
+            BloomFilter_mutated bf = new BloomFilter_mutated( 1, 0.000000001 );
+            fail( "should have thrown an exception: error value is not bounded by a precision or tolerance value." );
+        }
+        catch( RuntimeException e ) 
+        {
+            assertEquals( "Invalid params for bloom filter", e.getMessage() );
+        }
+
+        //
+        // Creating an unusable bloom filter (zero bits, zero hashes) should fail.
+        // 
+        try 
+        {
+            BloomFilter_mutated bf = new BloomFilter_mutated(199, 1.0);
+            fail( "should have thrown an exception: created an unusable bloom filter with zero bits and zero hashes." );
+        }
+        catch( RuntimeException e ) 
+        {
+            assertEquals( "Invalid params for bloom filter", e.getMessage() );
+        }
+
+        //
+        // Giving it an error value that is too big should fail.
+        // 
+        try 
+        {
+            BloomFilter_mutated bf = new BloomFilter_mutated(199, 100.0);
+            fail( "should have thrown an exception: error value is too big." );
+        }
+        catch( RuntimeException e ) 
+        {
+            assertEquals( "Invalid params for bloom filter", e.getMessage() );
+        }
+
+        //
+        // Adding more data than expected should fail.
+        // 
+        try 
+        {
+            byte []data = "add more entries than bytes available".getBytes();
+            BloomFilter_mutated bf0 = new BloomFilter_mutated(data, 1, 0.1); 
+            fail( "should have thrown an exception: too much data." );
+        }
+        catch( RuntimeException e ) 
+        {
+            assertEquals( "Expected 1 bytes, got 37", e.getMessage() );
+        }
+
+    }
+    
+
+    public void testValuesFromPublicAPI()
+    {
+        BloomFilter_mutated bf = null;
+        assertEquals(0.000000001, bf.errorPrecision);
+        
+        bf = new BloomFilter_mutated(1, 0.01);
+        assertEquals(2, bf.bytes);
+        assertEquals(1, bf.entries);
+        assertEquals(0.01, bf.error);
+        assertEquals(9, bf.bits);
+        assertEquals(7, bf.hashes);
+        //
+        bf = new BloomFilter_mutated(1, 0.1);
+        assertEquals(1, bf.bytes);
+        assertEquals(1, bf.entries);
+        assertEquals(0.1, bf.error);
+        assertEquals(4, bf.bits);
+        assertEquals(4, bf.hashes);        
+        //
+        bf = new BloomFilter_mutated(8, 0.000001);
+        assertEquals(29, bf.bytes);
+        assertEquals(8, bf.entries);
+        assertEquals(0.000001, bf.error);
+        assertEquals(230, bf.bits);
+        assertEquals(20, bf.hashes);        
+    }
+
+    
     public void testFilter() throws InvalidObjectException {
         BloomFilter bf = new BloomFilter(20, 0.01);
 

--- a/java/src/test/java/me/everything/inbloom/BloomFilterTest.java
+++ b/java/src/test/java/me/everything/inbloom/BloomFilterTest.java
@@ -9,94 +9,82 @@ import java.io.InvalidObjectException;
  */
 public class BloomFilterTest extends TestCase {
 
-    public void testCreateFilterWithBadParameters()
-    {
-        try 
-        {
-            BloomFilter_mutated bf = new BloomFilter_mutated( -1, 0.01 );
+    public void testCreateFilterWithBadParameters() {
+        try {
+            BloomFilter bf = new BloomFilter( -1, 0.01 );
             fail( "should have thrown an exception" );
         }
-        catch( RuntimeException e ) 
-        {
+        catch( RuntimeException e ) {
             assertEquals( "Invalid params for bloom filter", e.getMessage() );
         }
         
         //
         // Error value cannot be arbitrarily close to zero. Must be bounded.
         // 
-        try 
-        {
-            BloomFilter_mutated bf = new BloomFilter_mutated( 1, 0.000000001 );
+        try {
+            BloomFilter bf = new BloomFilter( 1, 0.000000001 );
             fail( "should have thrown an exception: error value is not bounded by a precision or tolerance value." );
         }
-        catch( RuntimeException e ) 
-        {
+        catch( RuntimeException e ) {
             assertEquals( "Invalid params for bloom filter", e.getMessage() );
         }
 
         //
         // Creating an unusable bloom filter (zero bits, zero hashes) should fail.
         // 
-        try 
-        {
-            BloomFilter_mutated bf = new BloomFilter_mutated(199, 1.0);
+        try {
+            BloomFilter bf = new BloomFilter(199, 1.0);
             fail( "should have thrown an exception: created an unusable bloom filter with zero bits and zero hashes." );
         }
-        catch( RuntimeException e ) 
-        {
+        catch( RuntimeException e ) {
             assertEquals( "Invalid params for bloom filter", e.getMessage() );
         }
 
         //
         // Giving it an error value that is too big should fail.
         // 
-        try 
-        {
-            BloomFilter_mutated bf = new BloomFilter_mutated(199, 100.0);
+        try {
+            BloomFilter bf = new BloomFilter(199, 100.0);
             fail( "should have thrown an exception: error value is too big." );
         }
-        catch( RuntimeException e ) 
-        {
+        catch( RuntimeException e ) {
             assertEquals( "Invalid params for bloom filter", e.getMessage() );
         }
 
         //
         // Adding more data than expected should fail.
         // 
-        try 
-        {
+        try {
             byte []data = "add more entries than bytes available".getBytes();
-            BloomFilter_mutated bf0 = new BloomFilter_mutated(data, 1, 0.1); 
+            BloomFilter bf0 = new BloomFilter(data, 1, 0.1); 
             fail( "should have thrown an exception: too much data." );
         }
-        catch( RuntimeException e ) 
-        {
+        catch( RuntimeException e ) {
             assertEquals( "Expected 1 bytes, got 37", e.getMessage() );
         }
 
     }
     
 
-    public void testValuesFromPublicAPI()
-    {
-        BloomFilter_mutated bf = null;
+    public void testValuesFromPublicAPI() {
+        BloomFilter bf = null;
         assertEquals(0.000000001, bf.errorPrecision);
         
-        bf = new BloomFilter_mutated(1, 0.01);
+        bf = new BloomFilter(1, 0.01);
         assertEquals(2, bf.bytes);
         assertEquals(1, bf.entries);
         assertEquals(0.01, bf.error);
         assertEquals(9, bf.bits);
         assertEquals(7, bf.hashes);
-        //
-        bf = new BloomFilter_mutated(1, 0.1);
+
+        bf = new BloomFilter(1, 0.1);
         assertEquals(1, bf.bytes);
         assertEquals(1, bf.entries);
         assertEquals(0.1, bf.error);
         assertEquals(4, bf.bits);
         assertEquals(4, bf.hashes);        
-        //
-        bf = new BloomFilter_mutated(8, 0.000001);
+
+        bf = new BloomFilter(8, 0.000001);
         assertEquals(29, bf.bytes);
         assertEquals(8, bf.entries);
         assertEquals(0.000001, bf.error);


### PR DESCRIPTION
Applied [mutation testing](http://confreaks.tv/videos/mwrc2014-re-thinking-regression-testing) with Ortask Mutator 1.9. Improved the quality of the tests (and the code) by 13% (from a score of 84.6% to 95.3%).
- Explicitly made public fields 'public'.
- Corrected the comparison of the error value by introducing bounds for it (added a new error precision field). 
  -- Best programming practice: floats/doubles should never be compared like ints.
- Made the new error precision part of the public API.
- Added needed tests to document behavior with bad and edge-case parameters.
